### PR TITLE
fix: CLIN-2417 largeur hpo non observe

### DIFF
--- a/src/components/Prescription/components/ClinicalSignsSelect/NotObservedSignsList.tsx
+++ b/src/components/Prescription/components/ClinicalSignsSelect/NotObservedSignsList.tsx
@@ -52,10 +52,12 @@ const NotObservedSignsList = ({ form, getName }: OwnProps) => {
                           style={{ marginLeft: 10 }}
                         >
                           <Text>
-                            {capitalize(hpoNode[CLINICAL_SIGNS_ITEM_KEY.NAME])}{' '}
-                            <Text type="secondary">
-                              ({hpoNode[CLINICAL_SIGNS_ITEM_KEY.TERM_VALUE]})
-                            </Text>
+                            <Space size={4} className={styles.notObservedHpotext}>
+                              {capitalize(hpoNode[CLINICAL_SIGNS_ITEM_KEY.NAME])}
+                              <Text type="secondary">
+                                ({hpoNode[CLINICAL_SIGNS_ITEM_KEY.TERM_VALUE]})
+                              </Text>
+                            </Space>
                           </Text>
                         </Form.Item>
                         <CloseOutlined className={styles.removeIcon} onClick={() => remove(name)} />

--- a/src/components/Prescription/components/ClinicalSignsSelect/index.module.scss
+++ b/src/components/Prescription/components/ClinicalSignsSelect/index.module.scss
@@ -52,3 +52,13 @@ $label-width: 350px;
   fill: $blue-8;
   color: $blue-8;
 }
+
+.notObservedHpotext{
+  :first-child {
+    width: max-content;
+  }
+}
+
+:global(.ant-form-item-control-input-content){
+  max-width: none;
+}


### PR DESCRIPTION
# FIX : [Formulaire] Étape 2 - Le signe clinique non observé s'affiche sur deux lignes

- closes #CLIN-2417

## Description
Alors qu’il y a de la place, le signe clinique non observé s’affiche sur deux lignes.

[JIRA LINK]

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI/Screenshot Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-prescription-ui/assets/52966302/16453c36-a7d3-4e40-9e88-a413c36b1549)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-prescription-ui/assets/52966302/8321ed6b-79cc-42fc-858b-5a8b851750db)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

