### PR TITLE
fix/CLIN-2407 signs can be added to non observed list as long as they are not in the observed list and checked

### DIFF
--- a/src/components/PhenotypeTree/index.tsx
+++ b/src/components/PhenotypeTree/index.tsx
@@ -104,6 +104,17 @@ const PhenotypeTree = ({
             options={currentOptions.map(({ name, hpo_id }) => ({ label: name, value: hpo_id }))}
             onChange={handleHpoSearchTermChanged}
             onSelect={(value: string) => {
+              const currentOptionsAsNodes: TreeNode[] = [];
+
+              currentOptions.forEach((option) => {
+                const optionAsTreeNode = hpoToTreeNode(option);
+                if (treeNodes.findIndex((n) => n.key === optionAsTreeNode.key) === -1) {
+                  currentOptionsAsNodes.push(optionAsTreeNode);
+                }
+              });
+
+              if (currentOptions.length > 0) setTreeNodes(treeNodes.concat(currentOptionsAsNodes));
+
               addTargetKey && addTargetKey(value);
             }}
           />

--- a/src/components/Prescription/components/ClinicalSignsSelect/NotObservedSignsList.tsx
+++ b/src/components/Prescription/components/ClinicalSignsSelect/NotObservedSignsList.tsx
@@ -86,7 +86,13 @@ const NotObservedSignsList = ({ form, getName }: OwnProps) => {
                   const currentValues = form.getFieldValue(
                     getName(CLINICAL_SIGNS_FI_KEY.SIGNS),
                   ) as IClinicalSignItem[];
-                  const valuesList = currentValues.map(({ value }) => value);
+                  const valuesList: string[] = [];
+
+                  currentValues.forEach((i) => {
+                    if (i[CLINICAL_SIGNS_ITEM_KEY.IS_OBSERVED]) {
+                      valuesList.push(i.value);
+                    }
+                  });
 
                   nodes
                     .filter(({ key }) => !valuesList.includes(key))


### PR DESCRIPTION
Should also fix issue with autocomplete not adding sign if all ancestor nodes are not open.

# FIX

- closes CLIN-2407

## Description

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2407)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI/Screenshot Approved from design

## Screenshot
### Before

### After

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

