### PR TITLE
fix: CLIN-2568 disable default observed sign checkbox if already unobserved

### DIFF
--- a/src/components/Prescription/components/ClinicalSignsSelect/ObservedSignsList.tsx
+++ b/src/components/Prescription/components/ClinicalSignsSelect/ObservedSignsList.tsx
@@ -28,7 +28,7 @@ interface OwnProps {
 const ObservedSignsList = ({ form, getName }: OwnProps) => {
   const formConfig = usePrescriptionFormConfig();
   const [isPhenotypeModalVisible, setIsPhenotypeModalVisible] = useState(false);
-  const [unboservedSigns, setUnobservedSigns] = useState<string[]>([]);
+  const [notObservedSigns, setNotObservedSigns] = useState<string[]>([]);
   const notObservedSignsField = Form.useWatch(
     getName(CLINICAL_SIGNS_FI_KEY.NOT_OBSERVED_SIGNS),
     form,
@@ -37,7 +37,7 @@ const ObservedSignsList = ({ form, getName }: OwnProps) => {
   const isDefaultHpo = (hpoValue: string) =>
     !!formConfig?.clinical_signs.default_list.find(({ value }) => value === hpoValue);
 
-  const isAlreadyUnobserved = (hpoValue: string) => unboservedSigns.indexOf(hpoValue) > -1;
+  const isAlreadyNotObserved = (hpoValue: string) => notObservedSigns.indexOf(hpoValue) > -1;
 
   const getNode = (index: number): IClinicalSignItem =>
     form.getFieldValue(getName(CLINICAL_SIGNS_FI_KEY.SIGNS))[index];
@@ -47,7 +47,7 @@ const ObservedSignsList = ({ form, getName }: OwnProps) => {
       (form.getFieldValue(
         getName(CLINICAL_SIGNS_FI_KEY.NOT_OBSERVED_SIGNS),
       ) as IClinicalSignItem[]) || [];
-    setUnobservedSigns(notObserved.map((sign) => sign[CLINICAL_SIGNS_ITEM_KEY.TERM_VALUE]));
+    setNotObservedSigns(notObserved.map((sign) => sign[CLINICAL_SIGNS_ITEM_KEY.TERM_VALUE]));
   }, [notObservedSignsField]);
 
   return (
@@ -76,7 +76,7 @@ const ObservedSignsList = ({ form, getName }: OwnProps) => {
                   const isDefaultHpoTerm = isDefaultHpo(
                     hpoNode[CLINICAL_SIGNS_ITEM_KEY.TERM_VALUE],
                   );
-                  const checkBoxShouldBeDisabled = isAlreadyUnobserved(
+                  const checkBoxShouldBeDisabled = isAlreadyNotObserved(
                     hpoNode[CLINICAL_SIGNS_ITEM_KEY.TERM_VALUE],
                   );
 

--- a/src/components/Prescription/components/ClinicalSignsSelect/ObservedSignsList.tsx
+++ b/src/components/Prescription/components/ClinicalSignsSelect/ObservedSignsList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
 import { CloseOutlined, PlusOutlined } from '@ant-design/icons';
 import ProLabel from '@ferlab/ui/core/components/ProLabel';
@@ -28,12 +28,27 @@ interface OwnProps {
 const ObservedSignsList = ({ form, getName }: OwnProps) => {
   const formConfig = usePrescriptionFormConfig();
   const [isPhenotypeModalVisible, setIsPhenotypeModalVisible] = useState(false);
+  const [unboservedSigns, setUnobservedSigns] = useState<string[]>([]);
+  const notObservedSignsField = Form.useWatch(
+    getName(CLINICAL_SIGNS_FI_KEY.NOT_OBSERVED_SIGNS),
+    form,
+  );
 
   const isDefaultHpo = (hpoValue: string) =>
     !!formConfig?.clinical_signs.default_list.find(({ value }) => value === hpoValue);
 
+  const isAlreadyUnobserved = (hpoValue: string) => unboservedSigns.indexOf(hpoValue) > -1;
+
   const getNode = (index: number): IClinicalSignItem =>
     form.getFieldValue(getName(CLINICAL_SIGNS_FI_KEY.SIGNS))[index];
+
+  useEffect(() => {
+    const notObserved =
+      (form.getFieldValue(
+        getName(CLINICAL_SIGNS_FI_KEY.NOT_OBSERVED_SIGNS),
+      ) as IClinicalSignItem[]) || [];
+    setUnobservedSigns(notObserved.map((sign) => sign[CLINICAL_SIGNS_ITEM_KEY.TERM_VALUE]));
+  }, [notObservedSignsField]);
 
   return (
     <Space direction="vertical">
@@ -61,6 +76,9 @@ const ObservedSignsList = ({ form, getName }: OwnProps) => {
                   const isDefaultHpoTerm = isDefaultHpo(
                     hpoNode[CLINICAL_SIGNS_ITEM_KEY.TERM_VALUE],
                   );
+                  const checkBoxShouldBeDisabled = isAlreadyUnobserved(
+                    hpoNode[CLINICAL_SIGNS_ITEM_KEY.TERM_VALUE],
+                  );
 
                   return (
                     <div key={key} className={styles.hpoFormItem}>
@@ -71,6 +89,7 @@ const ObservedSignsList = ({ form, getName }: OwnProps) => {
                           valuePropName="checked"
                         >
                           <Checkbox
+                            disabled={checkBoxShouldBeDisabled}
                             value={true}
                             data-cy={`Observed${hpoNode[CLINICAL_SIGNS_ITEM_KEY.TERM_VALUE]}`}
                           >

--- a/src/components/Prescription/components/ClinicalSignsSelect/ObservedSignsList.tsx
+++ b/src/components/Prescription/components/ClinicalSignsSelect/ObservedSignsList.tsx
@@ -181,7 +181,9 @@ const ObservedSignsList = ({ form, getName }: OwnProps) => {
                   const valuesList = currentValues.map(({ value }) => value);
 
                   nodes
-                    .filter(({ key }) => !valuesList.includes(key))
+                    .filter(
+                      ({ key }) => !valuesList.includes(key) && !notObservedSigns.includes(key),
+                    )
                     .forEach((node) =>
                       add({
                         [CLINICAL_SIGNS_ITEM_KEY.NAME]: extractPhenotypeTitleAndCode(node.title)


### PR DESCRIPTION
# FIX

- closes CLIN-2568

## Description

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2568)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI/Screenshot Approved from design

## Screenshot
### Before

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-prescription-ui/assets/6180385/a67a7e53-f79e-4a06-8da1-9114d824cac1)


## QA

Steps to validate
Url (storybook, ...)
...

## Mention

