### PR TITLE
fix: PRESC-224 enlever addParentButton no presc

### DIFF
--- a/src/views/Home/components/AddParent/index.tsx
+++ b/src/views/Home/components/AddParent/index.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import intl from 'react-intl-universal';
+import { useDispatch } from 'react-redux';
+import { tieBreaker } from '@ferlab/ui/core/components/ProTable/utils';
+import { ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
+import { SortDirection } from '@ferlab/ui/core/graphql/constants';
+import { Col } from 'antd';
+import { usePractitionnerPrescriptions } from 'graphql/prescriptions/actions';
+import { GraphqlBackend } from 'providers';
+import ApolloProvider from 'providers/ApolloProvider';
+import {
+  DEFAULT_OFFSET,
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_QUERY_CONFIG,
+  DEFAULT_SORT_QUERY,
+} from 'views/Prescriptions/PractitionerTable/utils/contstant';
+
+import FamilyRestroomIcon from 'components/icons/FamilyRestroomIcon';
+import { prescriptionFormActions } from 'store/prescription/slice';
+import { useUser } from 'store/user';
+
+import ActionButton from '../ActionButton';
+
+const AddParentButton = (): React.ReactElement => {
+  const dispatch = useDispatch();
+  const { user } = useUser();
+
+  const prescriptionsQueryVariables = {
+    first: DEFAULT_PAGE_SIZE,
+    offset: DEFAULT_OFFSET,
+    searchAfter: DEFAULT_QUERY_CONFIG.searchAfter,
+    sqon: {
+      content: [
+        {
+          op: 'in',
+          content: { field: 'requester', value: user.practitionerRoles.map((pr) => pr.id) },
+        },
+      ],
+      op: 'and',
+    } as ISyntheticSqon,
+    sort: tieBreaker({
+      sort: DEFAULT_QUERY_CONFIG.sort,
+      defaultSort: DEFAULT_SORT_QUERY,
+      field: '_id',
+      order: DEFAULT_QUERY_CONFIG.operations?.previous ? SortDirection.Asc : SortDirection.Desc,
+    }),
+  };
+
+  const prescriptions = usePractitionnerPrescriptions(
+    prescriptionsQueryVariables,
+    DEFAULT_QUERY_CONFIG.operations,
+  );
+
+  if (!prescriptions || prescriptions.total === 0) {
+    return <></>;
+  }
+
+  return (
+    <Col lg={12} flex="auto">
+      <ActionButton
+        disabled
+        icon={<FamilyRestroomIcon />}
+        title={intl.get('add.parent.to.existing.prescription')}
+        description={intl.get('find.analysis.and.add.family.member')}
+        onClick={() => dispatch(prescriptionFormActions.startAddParentChoice())}
+      />
+    </Col>
+  );
+};
+
+const AddParentButtonWrapper = () => (
+  <ApolloProvider backend={GraphqlBackend.ARRANGER}>
+    <AddParentButton />
+  </ApolloProvider>
+);
+
+export default AddParentButtonWrapper;

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -9,7 +9,6 @@ import { getUserFullName } from 'auth/keycloak';
 import DownloadButton from 'views/Prescriptions/components/DownloadDocument';
 import PractitionerTable from 'views/Prescriptions/PractitionerTable';
 
-import FamilyRestroomIcon from 'components/icons/FamilyRestroomIcon';
 import ContentWithHeader from 'components/Layout/ContentWithHeader';
 import ScrollContentWithFooter from 'components/Layout/ScrollContentWithFooter';
 import PrescriptionForm from 'components/Prescription';
@@ -21,6 +20,7 @@ import { prescriptionFormActions } from 'store/prescription/slice';
 import { DYNAMIC_ROUTES } from 'utils/routes';
 
 import ActionButton from './components/ActionButton';
+import AddParentButton from './components/AddParent';
 
 import styles from './index.module.scss';
 
@@ -80,7 +80,7 @@ const Home = () => {
             content={
               <Row gutter={[24, 24]}>
                 <LimitTo roles={[Roles.Prescriber, Roles.Practitioner]}>
-                  <Col lg={12} className={styles.contentCol} data-cy="CreateNewPrescription">
+                  <Col flex="auto" data-cy="CreateNewPrescription">
                     <ActionButton
                       icon={<MedicineBoxFilled />}
                       title={intl.get('create.new.prescription')}
@@ -88,15 +88,7 @@ const Home = () => {
                       onClick={() => dispatch(prescriptionFormActions.startAnalyseChoice())}
                     />
                   </Col>
-                  <Col lg={12} className={styles.contentCol}>
-                    <ActionButton
-                      disabled
-                      icon={<FamilyRestroomIcon />}
-                      title={intl.get('add.parent.to.existing.prescription')}
-                      description={intl.get('find.analysis.and.add.family.member')}
-                      onClick={() => dispatch(prescriptionFormActions.startAddParentChoice())}
-                    />
-                  </Col>
+                  {visibleTable && <AddParentButton />}
                 </LimitTo>
               </Row>
             }


### PR DESCRIPTION
# FIX : Afficher les boutons selon types HasPrescription = true vs false

- closes #PRESC-224

## Description
Ne pas afficher le bouton ajouter parent si aucune prescription

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/PRESC-224)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI/Screenshot Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-prescription-ui/assets/52966302/9e95b96b-c94c-4f0d-8f05-f1c8d843b334)

### After
![image](https://github.com/Ferlab-Ste-Justine/clin-prescription-ui/assets/52966302/62383109-7dd5-49e7-b66e-b979d93e05c7)
![image](https://github.com/Ferlab-Ste-Justine/clin-prescription-ui/assets/52966302/0a52eeef-effb-4b33-865d-788b0fd31a6e)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

