### PR TITLE
feat: PRESC-254 Skip create prescription test

### DIFF
--- a/cypress/e2e/FormulairesPrescription/CreationPrescription.cy.ts
+++ b/cypress/e2e/FormulairesPrescription/CreationPrescription.cy.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
   cy.get('[data-cy="CreateNewPrescription"]').should('exist', {timeout: 20*1000});
 });
 
-describe('Formulaires de prescription - Création', () => {
+describe.skip('Formulaires de prescription - Création', () => {
   it('MMG - Solo', () => {
     const strMRN = mrnValues[Math.floor(Math.random() * mrnValues.length)];
 


### PR DESCRIPTION
# FEAT : Désactiver le test de création de prescription

- closes [PRESC-254](https://ferlab-crsj.atlassian.net/browse/PRESC-254)

## Description

Les DevOps vont mettre en place un mécanisme d’automatisation des tests Cypress: [INFRA-555](https://ferlab-crsj.atlassian.net/browse/INFRA-555)

Afin d'éviter de créer beaucoup de prescriptions durant leur phase de tests, désactiver le test Cypress qui créé une prescription.


[PRESC-254]: https://ferlab-crsj.atlassian.net/browse/PRESC-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[INFRA-555]: https://ferlab-crsj.atlassian.net/browse/INFRA-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ