### PR TITLE
fix: PRESC-248 fix style

### DIFF
--- a/src/components/Prescription/components/ClinicalSignsSelect/index.module.scss
+++ b/src/components/Prescription/components/ClinicalSignsSelect/index.module.scss
@@ -54,8 +54,10 @@ $label-width: 350px;
 }
 
 .notObservedHpotext{
+  width: max-content;
   :first-child {
     width: max-content;
+    max-width: max-content;
   }
 }
 


### PR DESCRIPTION
# FIX : [Formulaire] Étape 2 - Le signe clinique non observé s'affiche sur deux lignes

- closes #PRESC-248

## Description

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/PRESC-248)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI/Screenshot Approved from design

## Screenshot
### Before
![image](https://github.com/Ferlab-Ste-Justine/clin-prescription-ui/assets/52966302/b23c7c94-9a9f-41b1-a78e-cc734e3f3093)


### After
![image](https://github.com/Ferlab-Ste-Justine/clin-prescription-ui/assets/52966302/1f169427-7d98-4038-8af4-25d974a7807a)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

