### PR TITLE
feat: PRESC-255 Setup env-qa file

### DIFF
--- a/env-qa
+++ b/env-qa
@@ -25,19 +25,17 @@ SASS_PATH=/code/src/style/themes/clin
 REACT_APP_FT_beta=true
 
 # Cypress
-
-CYPRESS_USERNAME_DG_CHUSJ_CUSM_CHUS=
-CYPRESS_USERNAME_G_CHUSJ_CUSM_CHUS=
-CYPRESS_USERNAME_DG_CHUSJ=
-CYPRESS_USERNAME_G_CHUSJ=
-CYPRESS_USERNAME_G_CUSM=
-CYPRESS_USERNAME_DG_CHUS=
-CYPRESS_USERNAME_G_CHUS=
-CYPRESS_USERNAME_D_CUSM=
-CYPRESS_USERNAME_R_CHUSJ=
-CYPRESS_PASSWORD=
-CYPRESS_PRESC_EP_CHUSJ_LDM_CHUSJ = {"stampDate": "TO_FILL", "prescriptionId": "TO_FILL", "patientProbId": "TO_FILL", "mrnProb": "MRN-283773", "firstNameProb": "Jacob", "lastNameProb": "CHAMPAGNE", "ramqProb": "CHAJ 1202 0376", "birthdayProb": "2012-02-03", "genderProb": "Masculin", "requestProbId": "TO_FILL", "sampleProbId": "NA24835_A", "patientMthId": "TO_FILL", "mrnMth": "mrn-283774", "requestMthId": "TO_FILL", "ramqMth": "MORL 7051 3037", "firstNameMth": "Lea", "lastNameMth": "MORIN", "birthdayMth": "1970-01-30", "statusMth": "Non atteint", "sampleMthId": "na24143_a", "patientFthId": "TO_FILL", "mrnFth": "MRN-283775", "requestFthId": "TO_FILL", "ramqFth": "CHAT 7303 2326", "firstNameFth": "Thomas", "lastNameFth": "CHAMPAGNE", "birthdayFth": "1973-03-23", "statusFth": "Non atteint", "sampleFthId": "NA24149_A"}
-CYPRESS_PRESC_EP_CUSM_LDM_CHUSJ  = {"prescriptionId": "TO_FILL", "patientProbId": "TO_FILL", "mrnProb": "MRN-283824", "firstNameProb": "Henri"}
-CYPRESS_PRESC_EP_CUSM_LDM_CUSM   = {"prescriptionId": "TO_FILL", "patientProbId": "TO_FILL", "mrnProb": "MRN-283897", "firstNameProb": "Maya"}
-CYPRESS_PRESC_EP_CHUS_LDM_CHUS   = {"prescriptionId": "TO_FILL", "patientProbId": "TO_FILL", "mrnProb": "MRN-283834", "firstNameProb": "Tristan"}
+CYPRESS_USERNAME_DG_CHUSJ_CUSM_CHUS="cypress.test.pg@chusjcusmchus.org"
+CYPRESS_USERNAME_G_CHUSJ_CUSM_CHUS="jean.leblanc.g@chusjcusmchus.org"
+CYPRESS_USERNAME_DG_CHUSJ="genevieve.beauchamp.pg@chusj.org"
+CYPRESS_USERNAME_G_CHUSJ="delima.simard.g@chusj.org"
+CYPRESS_USERNAME_G_CUSM="suzanne.paquet.g@cusm.org"
+CYPRESS_USERNAME_DG_CHUS="josephine.poirier.pg@chus.org"
+CYPRESS_USERNAME_G_CHUS="paul.parent.g@chus.org"
+CYPRESS_USERNAME_D_CUSM="victor.robitaille.p@cusm.org"
+CYPRESS_USERNAME_R_CHUSJ="sophia.charron.r@chusj.org"
+CYPRESS_PRESC_EP_CHUSJ_LDM_CHUSJ = {"annotationDate": "2024-04-10", "stampDate": "2024-04-10", "prescriptionId": "1282128", "patientProbId": "1282129", "mrnProb": "MRN-283773", "firstNameProb": "Jacob", "lastNameProb": "CHAMPAGNE", "ramqProb": "CHAJ 1202 0376", "birthdayProb": "2012-02-03", "genderProb": "Masculin", "bioAnalProbId": "1282124", "requestProbId": "1282125", "sampleProbId": "NA24835_A", "aliquotProbId": "16774", "patientMthId": "1282142", "mrnMth": "mrn-283774", "requestMthId": "1282139", "ramqMth": "MORL 7051 3037", "firstNameMth": "Lea", "lastNameMth": "MORIN", "birthdayMth": "1970-01-30", "statusMth": "Non atteint", "sampleMthId": "na24143_a", "patientFthId": "1282155", "mrnFth": "MRN-283775", "bioAnalFthId": "1282151", "requestFthId": "1282152", "ramqFth": "CHAT 7303 2326", "firstNameFth": "Thomas", "lastNameFth": "CHAMPAGNE", "birthdayFth": "1973-03-23", "statusFth": "Non atteint", "sampleFthId": "NA24149_A"}
+CYPRESS_PRESC_EP_CUSM_LDM_CHUSJ  = {"prescriptionId": "1282684", "patientProbId": "1282685", "mrnProb": "MRN-283824", "firstNameProb": "Henri"}
+CYPRESS_PRESC_EP_CUSM_LDM_CUSM   = {"prescriptionId": "1283483", "patientProbId": "1283484", "mrnProb": "MRN-283897", "firstNameProb": "Maya"}
+CYPRESS_PRESC_EP_CHUS_LDM_CHUS   = {"prescriptionId": "1282794", "patientProbId": "1282795", "mrnProb": "MRN-283834", "firstNameProb": "Tristan"}
 


### PR DESCRIPTION
# FEAT : Setup env-qa file

- closes [PRESC-255](https://ferlab-crsj.atlassian.net/browse/PRESC-255)

## Description

Définir les variables pour les tests Cypress dans le fichier env-qa.

[PRESC-255]: https://ferlab-crsj.atlassian.net/browse/PRESC-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ