### PR TITLE
feat: PRESC-264 Fetch Fhir values for Cypress tests

### DIFF
--- a/cypress/e2e/AccesUtilisateurs/ParRole.cy.ts
+++ b/cypress/e2e/AccesUtilisateurs/ParRole.cy.ts
@@ -1,10 +1,18 @@
 /// <reference types="Cypress" />
 import '../../support/commands';
 
-const epCHUSJ_ldmCHUSJ = JSON.parse(Cypress.env('presc_EP_CHUSJ_LDM_CHUSJ'));
-const epCUSM_ldmCHUSJ = JSON.parse(Cypress.env('presc_EP_CUSM_LDM_CHUSJ'));
-const epCUSM_ldmCUSM = JSON.parse(Cypress.env('presc_EP_CUSM_LDM_CUSM'));
-const epCHUS_ldmCHUS = JSON.parse(Cypress.env('presc_EP_CHUS_LDM_CHUS'));
+let epCHUSJ_ldmCHUSJ: any;
+let epCUSM_ldmCHUSJ: any;
+let epCUSM_ldmCUSM: any;
+let epCHUS_ldmCHUS: any;
+
+beforeEach(() => {
+  epCHUSJ_ldmCHUSJ = Cypress.env('globalData').presc_EP_CHUSJ_LDM_CHUSJ;
+  epCUSM_ldmCHUSJ = Cypress.env('globalData').presc_EP_CUSM_LDM_CHUSJ;
+  epCUSM_ldmCUSM = Cypress.env('globalData').presc_EP_CUSM_LDM_CUSM;
+  epCHUS_ldmCHUS = Cypress.env('globalData').presc_EP_CHUS_LDM_CHUS;
+  cy.login(Cypress.env('username_DG_CHUSJ_CUSM_CHUS'), Cypress.env('password'));
+});
 
 describe('Accès des utilisateurs', () => {
   it('Docteur et généticien (CHUSJ, CUSM, CHUS)', () => {

--- a/cypress/e2e/Consultation/PagePrescription.cy.ts
+++ b/cypress/e2e/Consultation/PagePrescription.cy.ts
@@ -1,9 +1,10 @@
 /// <reference types="Cypress" />
 import '../../support/commands';
 
-const epCHUSJ_ldmCHUSJ = JSON.parse(Cypress.env('presc_EP_CHUSJ_LDM_CHUSJ'));
+let epCHUSJ_ldmCHUSJ: any;
 
 beforeEach(() => {
+  epCHUSJ_ldmCHUSJ = Cypress.env('globalData').presc_EP_CHUSJ_LDM_CHUSJ;
   cy.login(Cypress.env('username_DG_CHUSJ_CUSM_CHUS'), Cypress.env('password'));
   cy.visitPrescriptionEntityPage(epCHUSJ_ldmCHUSJ.prescriptionId);
 });

--- a/cypress/e2e/Navigation/Pages.cy.ts
+++ b/cypress/e2e/Navigation/Pages.cy.ts
@@ -1,14 +1,14 @@
 /// <reference types="Cypress" />
 import '../../support/commands';
 
-const epCHUSJ_ldmCHUSJ = JSON.parse(Cypress.env('presc_EP_CHUSJ_LDM_CHUSJ'));
+let epCHUSJ_ldmCHUSJ: any;
+
+beforeEach(() => {
+  epCHUSJ_ldmCHUSJ = Cypress.env('globalData').presc_EP_CHUSJ_LDM_CHUSJ;
+  cy.login(Cypress.env('username_DG_CHUSJ_CUSM_CHUS'), Cypress.env('password'));
+});
 
 describe('Affichage de toutes les pages et modals', () => {
-
-  beforeEach(() => {
-    cy.login(Cypress.env('username_DG_CHUSJ_CUSM_CHUS'), Cypress.env('password'));
-  });
-
   it('Accueil', () => {
     cy.visit('/');
     cy.contains('Beta').should('exist', {timeout: 20*1000});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,12 +1,164 @@
 /* eslint-disable */
 /// <reference types="Cypress" />
 import './commands';
+import {getGlobalData} from './globalData';
+
+let token;
+let globalData = getGlobalData();
+
+Cypress.Commands.add('fetchFhirValues', () => {
+  const username = Cypress.env('username_DG_CHUSJ_CUSM_CHUS');
+  const password = Cypress.env('password');
+
+  return cy.request({
+    method: 'GET',
+    url: `https://qlin-me.qa.cqgc.hsj.rtss.qc.ca/api/v1/auth/login?email=${username}&password=${password}`,
+    failOnStatusCode: false,
+  }).then((response) => {
+    token = response.body.token;
+    expect(token).to.exist;
+  return cy.request({
+    method: 'POST',
+    url: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir',
+    headers: { 'Authorization': `Bearer ${token}` },
+    body: {
+      "entry": [
+        {
+          "request": {
+          "method": "GET",
+          "url": `/Patient?identifier=${globalData.presc_EP_CHUSJ_LDM_CHUSJ.mrnProb}`
+          }
+        },
+        {
+          "request": {
+          "method": "GET",
+          "url": `/Patient?identifier=${globalData.presc_EP_CHUSJ_LDM_CHUSJ.mrnMth}`
+          }
+        },
+        {
+          "request": {
+          "method": "GET",
+          "url": `/Patient?identifier=${globalData.presc_EP_CHUSJ_LDM_CHUSJ.mrnFth}`
+          }
+        },
+        {
+          "request": {
+          "method": "GET",
+          "url": `/Patient?identifier=${globalData.presc_EP_CUSM_LDM_CHUSJ.mrnProb}`
+          }
+        },
+        {
+          "request": {
+          "method": "GET",
+          "url": `/Patient?identifier=${globalData.presc_EP_CUSM_LDM_CUSM.mrnProb}`
+          }
+        },
+        {
+          "request": {
+          "method": "GET",
+          "url": `/Patient?identifier=${globalData.presc_EP_CHUS_LDM_CHUS.mrnProb}`
+          }
+        }
+      ],
+      "id": "bundle-request-patient-data",
+      "resourceType": "Bundle",
+      "type": "batch"
+    },
+    failOnStatusCode: false,
+  });
+  }).then((response) => {
+    let fhirValues = response.body;
+    globalData.presc_EP_CHUSJ_LDM_CHUSJ.patientProbId = fhirValues.entry[0].resource.entry[0].resource.id;
+    globalData.presc_EP_CHUSJ_LDM_CHUSJ.stampDate = fhirValues.entry[0].resource.entry[0].resource.meta.lastUpdated.split('T')[0];
+    globalData.presc_EP_CHUSJ_LDM_CHUSJ.patientMthId = fhirValues.entry[1].resource.entry[0].resource.id;
+    globalData.presc_EP_CHUSJ_LDM_CHUSJ.patientFthId = fhirValues.entry[2].resource.entry[0].resource.id;
+    globalData.presc_EP_CUSM_LDM_CHUSJ.patientProbId = fhirValues.entry[3].resource.entry[0].resource.id;
+    globalData.presc_EP_CUSM_LDM_CUSM.patientProbId = fhirValues.entry[4].resource.entry[0].resource.id;
+    globalData.presc_EP_CHUS_LDM_CHUS.patientProbId = fhirValues.entry[5].resource.entry[0].resource.id;
+
+    return cy.request({
+      method: 'POST',
+      url: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir',
+      headers: { 'Authorization': `Bearer ${token}` },
+      body: {
+        "entry": [
+          {
+            "request": {
+            "method": "GET",
+            "url": `/ServiceRequest?patient=${globalData.presc_EP_CHUSJ_LDM_CHUSJ.patientProbId}&code=75020`
+            }
+          },
+          {
+            "request": {
+            "method": "GET",
+            "url": `/ServiceRequest?patient=${globalData.presc_EP_CHUSJ_LDM_CHUSJ.patientMthId}&code=75020`
+            }
+          },
+          {
+            "request": {
+            "method": "GET",
+            "url": `/ServiceRequest?patient=${globalData.presc_EP_CHUSJ_LDM_CHUSJ.patientFthId}&code=75020`
+            }
+          },
+          {
+            "request": {
+            "method": "GET",
+            "url": `/Task?patient=${globalData.presc_EP_CHUSJ_LDM_CHUSJ.patientProbId}`
+            }
+          },
+          {
+            "request": {
+            "method": "GET",
+            "url": `/Task?patient=${globalData.presc_EP_CHUSJ_LDM_CHUSJ.patientFthId}`
+            }
+          },
+          {
+            "request": {
+            "method": "GET",
+            "url": `/ServiceRequest?patient=${globalData.presc_EP_CUSM_LDM_CHUSJ.patientProbId}&code=75020`
+            }
+          },
+          {
+            "request": {
+            "method": "GET",
+            "url": `/ServiceRequest?patient=${globalData.presc_EP_CUSM_LDM_CUSM.patientProbId}&code=75020`
+            }
+          },
+          {
+            "request": {
+            "method": "GET",
+            "url": `/ServiceRequest?patient=${globalData.presc_EP_CHUS_LDM_CHUS.patientProbId}&code=75020`
+            }
+          }
+        ],
+        "id": "bundle-request-patient-data",
+        "resourceType": "Bundle",
+        "type": "batch"
+      },
+      failOnStatusCode: false,
+    });
+  }).then((response) => {
+    let fhirValues = response.body;
+    globalData.presc_EP_CHUSJ_LDM_CHUSJ.prescriptionId = fhirValues.entry[0].resource.entry[0].resource.basedOn[0].reference.split('/')[1];
+    globalData.presc_EP_CHUSJ_LDM_CHUSJ.requestProbId = fhirValues.entry[0].resource.entry[0].resource.id;
+    globalData.presc_EP_CHUSJ_LDM_CHUSJ.requestMthId = fhirValues.entry[1].resource.entry[0].resource.id;
+    globalData.presc_EP_CHUSJ_LDM_CHUSJ.requestFthId = fhirValues.entry[2].resource.entry[0].resource.id;
+    globalData.presc_EP_CHUSJ_LDM_CHUSJ.bioAnalProbId = fhirValues.entry[3].resource.entry[0].resource.id;
+    globalData.presc_EP_CHUSJ_LDM_CHUSJ.bioAnalFthId = fhirValues.entry[4].resource.entry[0].resource.id;
+    globalData.presc_EP_CUSM_LDM_CHUSJ.prescriptionId = fhirValues.entry[5].resource.entry[0].resource.basedOn[0].reference.split('/')[1];
+    globalData.presc_EP_CUSM_LDM_CUSM.prescriptionId = fhirValues.entry[6].resource.entry[0].resource.basedOn[0].reference.split('/')[1];
+    globalData.presc_EP_CHUS_LDM_CHUS.prescriptionId = fhirValues.entry[7].resource.entry[0].resource.basedOn[0].reference.split('/')[1];
+
+    Cypress.env('globalData', globalData);
+  });
+});
 
 // Ignore uncaught exception so tests doesn't stop mid run
 Cypress.on('uncaught:exception', () => false);
 
 before(() => {
   cy.exec('npm cache clear --force');
+  cy.fetchFhirValues();
   cy.wait(1000);
 });
 

--- a/cypress/support/globalData.js
+++ b/cypress/support/globalData.js
@@ -1,0 +1,62 @@
+const globalData = {
+  presc_EP_CHUSJ_LDM_CHUSJ: {
+    mrnProb: 'MRN-283773',
+    stampDate: 'willBeSetByFetchFhirValues',
+    prescriptionId: 'willBeSetByFetchFhirValues',
+    patientProbId: 'willBeSetByFetchFhirValues',
+    firstNameProb: 'Jacob',
+    lastNameProb: 'CHAMPAGNE',
+    ramqProb: 'CHAJ 1202 0376',
+    birthdayProb: '2012-02-03',
+    genderProb: 'Masculin',
+    bioAnalProbId: 'willBeSetByFetchFhirValues',
+    requestProbId: 'willBeSetByFetchFhirValues',
+    sampleProbId: 'NA24835_A',
+    aliquotProbId: '16774',
+    patientMthId: 'willBeSetByFetchFhirValues',
+    mrnMth: 'MRN-283774',
+    requestMthId: 'willBeSetByFetchFhirValues',
+    ramqMth: 'MORL 7051 3037',
+    firstNameMth: 'Lea',
+    lastNameMth: 'MORIN',
+    birthdayMth: '1970-01-30',
+    statusMth: 'Non atteint',
+    sampleMthId: 'na24143_a',
+    patientFthId: 'willBeSetByFetchFhirValues',
+    mrnFth: 'MRN-283775',
+    bioAnalFthId: 'willBeSetByFetchFhirValues',
+    requestFthId: 'willBeSetByFetchFhirValues',
+    ramqFth: 'CHAT 7303 2326',
+    firstNameFth: 'Thomas',
+    lastNameFth: 'CHAMPAGNE',
+    birthdayFth: '1973-03-23',
+    statusFth: 'Non atteint',
+    sampleFthId: 'NA24149_A',
+  },
+  presc_EP_CUSM_LDM_CHUSJ: {
+    mrnProb: 'MRN-283824',
+    prescriptionId: 'willBeSetByFetchFhirValues',
+    patientProbId: 'willBeSetByFetchFhirValues',
+    firstNameProb: 'Henri',
+  },
+  presc_EP_CUSM_LDM_CUSM: {
+    mrnProb: 'MRN-283897',
+    prescriptionId: 'willBeSetByFetchFhirValues',
+    patientProbId: 'willBeSetByFetchFhirValues',
+    firstNameProb: 'Maya',
+  },
+  presc_EP_CHUS_LDM_CHUS: {
+    mrnProb: 'MRN-283834',
+    prescriptionId: 'willBeSetByFetchFhirValues',
+    patientProbId: 'willBeSetByFetchFhirValues',
+    firstNameProb: 'Tristan',
+  },
+};
+
+function getGlobalData() {
+  return globalData;
+}
+
+export default {
+  getGlobalData,
+};

--- a/env-qa
+++ b/env-qa
@@ -35,8 +35,3 @@ CYPRESS_USERNAME_G_CHUS="paul.parent.g@chus.org"
 CYPRESS_USERNAME_D_CUSM="victor.robitaille.p@cusm.org"
 CYPRESS_USERNAME_R_CHUSJ="sophia.charron.r@chusj.org"
 CYPRESS_PASSWORD=""
-CYPRESS_PRESC_EP_CHUSJ_LDM_CHUSJ = {"annotationDate": "2024-04-10", "stampDate": "2024-04-10", "prescriptionId": "1282128", "patientProbId": "1282129", "mrnProb": "MRN-283773", "firstNameProb": "Jacob", "lastNameProb": "CHAMPAGNE", "ramqProb": "CHAJ 1202 0376", "birthdayProb": "2012-02-03", "genderProb": "Masculin", "bioAnalProbId": "1282124", "requestProbId": "1282125", "sampleProbId": "NA24835_A", "aliquotProbId": "16774", "patientMthId": "1282142", "mrnMth": "mrn-283774", "requestMthId": "1282139", "ramqMth": "MORL 7051 3037", "firstNameMth": "Lea", "lastNameMth": "MORIN", "birthdayMth": "1970-01-30", "statusMth": "Non atteint", "sampleMthId": "na24143_a", "patientFthId": "1282155", "mrnFth": "MRN-283775", "bioAnalFthId": "1282151", "requestFthId": "1282152", "ramqFth": "CHAT 7303 2326", "firstNameFth": "Thomas", "lastNameFth": "CHAMPAGNE", "birthdayFth": "1973-03-23", "statusFth": "Non atteint", "sampleFthId": "NA24149_A"}
-CYPRESS_PRESC_EP_CUSM_LDM_CHUSJ  = {"prescriptionId": "1282684", "patientProbId": "1282685", "mrnProb": "MRN-283824", "firstNameProb": "Henri"}
-CYPRESS_PRESC_EP_CUSM_LDM_CUSM   = {"prescriptionId": "1283483", "patientProbId": "1283484", "mrnProb": "MRN-283897", "firstNameProb": "Maya"}
-CYPRESS_PRESC_EP_CHUS_LDM_CHUS   = {"prescriptionId": "1282794", "patientProbId": "1282795", "mrnProb": "MRN-283834", "firstNameProb": "Tristan"}
-


### PR DESCRIPTION
# FEAT : Fetch Fhir values for Cypress tests

- closes #PRESC-264

## Description

[PRESC-264](https://ferlab-crsj.atlassian.net/browse/PRESC-264)

[PRESC-264]: https://ferlab-crsj.atlassian.net/browse/PRESC-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ