### PR TITLE
feat: PRESC-265 Unskip skipped Cypress test and remove sunday execution

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -45,7 +45,7 @@ resources:
     start: "03:00 AM"
     stop: "04:30 AM"
     location: "America/Toronto"
-    days: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Sunday"]
+    days: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
 
 - name: slack-alert-cypress
   type: slack-notification

--- a/cypress/e2e/FormulairesPrescription/CreationPrescription.cy.ts
+++ b/cypress/e2e/FormulairesPrescription/CreationPrescription.cy.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
   cy.get('[data-cy="CreateNewPrescription"]').should('exist', {timeout: 20*1000});
 });
 
-describe.skip('Formulaires de prescription - Création', () => {
+describe('Formulaires de prescription - Création', () => {
   it('MMG - Solo', () => {
     const strMRN = mrnValues[Math.floor(Math.random() * mrnValues.length)];
 


### PR DESCRIPTION
# FEAT : Unskip skipped Cypress test and remove sunday execution

- closes #PRESC-265

## Description

[PRESC-265](https://ferlab-crsj.atlassian.net/browse/PRESC-265)

[PRESC-265]: https://ferlab-crsj.atlassian.net/browse/PRESC-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ